### PR TITLE
Rename "Design Token App" to Engramma in blog

### DIFF
--- a/apps/svelte.dev/content/blog/2025-12-01-whats-new-in-svelte-december-2025.md
+++ b/apps/svelte.dev/content/blog/2025-12-01-whats-new-in-svelte-december-2025.md
@@ -37,7 +37,7 @@ For a full list of changes - including all the important bugfixes that went into
 - [ShareNhac](https://www.sharenhac.com/) lets you and your friends watch videos and listen to music together in sync, without any ad interruptions
 - [starterindex](https://starterindex.com/) is a curated list of top boilerplates to help you start your next project (which is great because we stopped putting "starter" repos in the Svelte newsletter over a year ago)
 - [PGPlayground](https://pg.firoz.co/playground) helps any backend engineer quickly prototype and validate fixes or changes to their schema without leaving the browser
-- [Design Tokens App](https://tools-for-web.netlify.app) is a web-based editor and converter to manage design tokens, visualize them in a tree structure, and export them as CSS variables or JSON format
+- [Engramma](https://engramma.dev) is a web-based editor and converter to manage design tokens, visualize them in a tree structure, and export them as CSS variables, SCSS or JSON format
 - [Multi](https://multi.dev/) is a coding agent for VS Code
 - [Gardenjs](https://gardenjs.org/) provides a centralized platform for developers to create, test, and present UI components and pages in isolation
 - [bookemoji](https://bookemoji.dev/) is a tool to showcase, collaborate, and develop the technical aspects of user interfaces - an alternative to StoryBook.js or Histoire in your favorite tech stack


### PR DESCRIPTION
Hey, I am author of Engramma app for design tokens. Recently gave it a name.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
